### PR TITLE
Bugfix: Background crashing.

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -14,7 +14,7 @@
         android:icon="@drawable/icon"
         android:label="@string/app_name"
         android:theme="@style/AppTheme" >
-        <service android:enabled="true" android:name="BitDayLiveWallpaperService" android:label="Bit Day Wallpaper" android:permission="android.permission.BIND_WALLPAPER">
+        <service android:enabled="true" android:name="LiveWallpaperService" android:label="Bit Day Wallpaper" android:permission="android.permission.BIND_WALLPAPER">
             <intent-filter>
                 <action android:name="android.service.wallpaper.WallpaperService"/>
             </intent-filter>

--- a/bin/AndroidManifest.xml
+++ b/bin/AndroidManifest.xml
@@ -14,7 +14,7 @@
         android:icon="@drawable/icon"
         android:label="@string/app_name"
         android:theme="@style/AppTheme" >
-        <service android:enabled="true" android:name="BitDayLiveWallpaperService" android:label="Bit Day Wallpaper" android:permission="android.permission.BIND_WALLPAPER">
+        <service android:enabled="true" android:name="LiveWallpaperService" android:label="Bit Day Wallpaper" android:permission="android.permission.BIND_WALLPAPER">
             <intent-filter>
                 <action android:name="android.service.wallpaper.WallpaperService"/>
             </intent-filter>


### PR DESCRIPTION
I seem to have fixed the background crashing.

The problem was how I listened for changes in the time, using a BroadcastReceiver.
The receiver would still listen, and when the hour changed, ask wallpapers to redraw themselves.
If a wallpaper wasn't visible at that time, e.g. because it was obscured by an app, an error would occur and the wallpaper would crash.

Now, every wallpaper have their own receiver, which is only active when the wallpaper is visible.
